### PR TITLE
add MIT license metadata to gemspec

### DIFF
--- a/inflecto.gemspec
+++ b/inflecto.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |gem|
   gem.description = 'Inflector for strings'
   gem.summary     = gem.description
   gem.homepage    = 'https://github.com/mbj/inflecto'
+  gem.license     = 'MIT'
 
   gem.require_paths    = %w[lib]
   gem.files            = `git ls-files`.split($/)


### PR DESCRIPTION
This pull request allows RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
