### PR TITLE
devtools dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ gemspec
 
 gem 'inflecto', :path => '.'
 
-gem 'devtools', :git => 'https://github.com/rom-rb/devtools.git'
+gem 'devtools', :git => 'https://github.com/mbj/devtools.git',
+                :ref => '745b9ba21a15cfe05af29341265437e983427e13'
 eval File.read('Gemfile.devtools')


### PR DESCRIPTION
I just fixed the devtools repo at a [working commit](https://github.com/mbj/devtools/commit/745b9ba21a15cfe05af29341265437e983427e13)

Wasn't sure if updating to the latest devtools version was appropriate since that would drop ruby < 2.1 support, so I leave the question here to see how to proceed.