### PR TITLE
Remove duplicate gem dependency from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'inflecto', :path => '.'
-
 group :development, :test do
   gem 'devtools', '~> 0.1.x'
 end


### PR DESCRIPTION
It fixes an error preventing modern Bundler versions from installing dependencies.